### PR TITLE
Fix duplicate use of Affiliate in use statement

### DIFF
--- a/src/Model/AffiliateProgram.php
+++ b/src/Model/AffiliateProgram.php
@@ -2,14 +2,14 @@
 
 namespace TPerformant\API\Model;
 
-use TPerformant\API\HTTP\Affiliate;
+use TPerformant\API\HTTP\Affiliate as ApiHttpAffiliate;
 use TPerformant\API\Filter\AffiliateCommissionFilter;
 
 class AffiliateProgram extends Program {
     /**
      * @inheritdoc
      */
-    public function __construct($data, Affiliate $user = null) {
+    public function __construct($data, ApiHttpAffiliate $user = null) {
         parent::__construct($data, $user);
     }
 


### PR DESCRIPTION
The fatal error is thrown due to the duplicate use of Affiliate
```
Fatal error: Cannot use TPerformant\API\HTTP\Affiliate as Affiliate because the name is already in use in vendor/2performant/2performant-php/src/Model/AffiliateProgram.php on line 5
```